### PR TITLE
Correct whitesource.config defaults

### DIFF
--- a/whitesource.config
+++ b/whitesource.config
@@ -2,21 +2,14 @@
 # This config file has been created from the above link and is used in all WS Native Repo Integrations by default
 # This file is meant to be used as a template when switching from AUTO to LOCAL configMode in the .whitesource file
 
-# rg: made a few changes based on most recent UA versions, see comments below
-#    randy.geyer@whitesourcesoftware.com
-
 maven.ignoreSourceFiles=true
 maven.ignoreMvnTreeErrors=true
-# rg: added maven.aggregateModules=true for better multi-module support
-maven.aggregateModules=true
 
 gradle.ignoreSourceFiles=true
-# rg: added gradle.aggregateModules=true for better multi-module support
-gradle.aggregateModules=true
+gradle.runPreStep=true
 
 npm.includeDevDependencies=false
-# rg: uses npm.runPreStep=false (default), uncomment next line if you don't get good npm results
-#npm.runPreStep=true
+npm.runPreStep=true
 npm.ignoreNpmLsErrors=true
 npm.yarnProject=false
 
@@ -30,19 +23,19 @@ paket.ignoreSourceFiles=true
 
 python.ignorePipInstallErrors=true
 python.installVirtualenv=true
-python.resolveSetupPyFiles=true
+python.resolveSetupFiles=true
 python.runPipenvPreStep=true
 python.pipenvDevDependencies=true
 python.IgnorePipenvInstallErrors=true
 python.runPoetryPreStep=true
-
+    
 go.collectDependenciesAtRuntime=true
 go.ignoreSourceFiles=true
 
 sbt.runPreStep=true
 
 r.runPreStep=true
-r.cranMirrorUrl=https://cloud.r-project.org/
+r.cranMirrorUrl=https=//cloud.r-project.org/
 
 php.runPreStep=true
 php.includeDevDependencies=true
@@ -57,10 +50,10 @@ hex.runPreStep=true
 haskell.runPreStep=true
 haskell.ignorePreStepErrors=true
 
-includes=**/*c **/*cc **/*cp **/*cpp **/*cxx **/*c++ **/*h **/*hh **/*hpp **/*hxx **/*h++ **/*m **/*mm **/*pch **/*c# **/*cs **/*csharp **/*go **/*goc **/*js **/*pl **/*plx **/*pm **/*ph **/*cgi **/*fcgi **/*pod **/*psgi **/*al **/*perl **/*t **/*pl6 **/*p6m **/*p6l **/*pm6 **/*nqp **/*6pl **/*6pm **/*p6 **/*php **/*py **/*rb **/*swift **/*java **/*clj **/*cljx **/*cljs **/*cljc **/*jar **/*egg **/*dll **/*tar.gz **/*tgz **/*zip **/*whl **/*gem **/*apk **/*air **/*dmg **/*exe **/*gem **/*gzip **/*msi **/*nupkg **/*swc **/*swf **/tar.bz2 **/pkg.tar.xz **/(u)?deb **/(a)?rpm
-# rg: added **/target to the SCM default excludes
-excludes=*/., **/node_modules, **/src/test, **/testdata, **/*sources.jar, **/*javadoc.jar, **/target
+includes=**/*.c,**/*.cc,**/*.cp,**/*.cpp,**/*.cxx,**/*.c\+\+,**/*.h,**/*.hh,**/*.hpp,**/*.hxx,**/*.h\+\+,**/*.m,**/*.mm,**/*.pch,**/*.c#,**/*.cs,**/*.csharp,**/*.go,**/*.goc,**/*.js,**/*.pl,**/*.plx,**/*.pm,**/*.ph,**/*.cgi,**/*.fcgi,**/*.pod,**/*.psgi,**/*.al,**/*.perl,**/*.t,**/*.pl6,**/*.p6m,**/*.p6l,**/*.pm6,**/*.nqp,**/*.6pl,**/*.6pm,**/*.p6,**/*.php,**/*.py,**/*.rb,**/*.swift,**/*.java,**/*.clj,**/*.cljx,**/*.cljs,**/*.cljc,**/*.jar,**/*.egg,**/*.dll,**/*.tar.gz,**/*.tgz,**/*.zip,**/*.whl,**/*.gem,**/*.apk,**/*.air,**/*.dmg,**/*.exe,**/*.gem,**/*.gzip,**/*.msi,**/*.nupkg,**/*.swc,**/*.swf,**/*.tar.bz2,**/*.pkg.tar.xz,**/*.(u)?deb,**/*.(a)?rpm
+
+excludes=*/., **/node_modules, **/src/test, **/testdata, **/*sources.jar, **/*javadoc.jar
 
 archiveExtractionDepth=0
-archiveIncludes=**/*war **/*ear **/*zip **/*whl **/*tar.gz **/*tgz **/*tar **/*car
-archiveExcludes=**/*sources.jar **/*javadoc.jar
+archiveIncludes=**/*.war,**/*.ear,**/*.zip,**/*.whl,**/*.tar.gz,**/*.tgz,**/*.tar,**/*.car
+archiveExcludes=**/*sources.jar,**/*javadoc.jar,**/tests/**

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,4 +1,4 @@
-# https://whitesource.atlassian.net/wiki/spaces/WD/pages/1781760001/Unified+Agent+Configuration+Parameters+for+Native+Integrations
+# https://docs.mend.io/bundle/unified_agent/page/unified_agent_configuration_for_native_integrations.html
 # This config file has been created from the above link and is used in all WS Native Repo Integrations by default
 # This file is meant to be used as a template when switching from AUTO to LOCAL configMode in the .whitesource file
 

--- a/whitesource_rg.config
+++ b/whitesource_rg.config
@@ -1,0 +1,66 @@
+# https://whitesource.atlassian.net/wiki/spaces/WD/pages/1781760001/Unified+Agent+Configuration+Parameters+for+Native+Integrations
+# This config file has been created from the above link and includes suggestions from randy geyer for various use cases.
+
+
+# rg: made a few changes based on most recent UA versions, see comments below
+#    randy.geyer@whitesourcesoftware.com
+
+maven.ignoreSourceFiles=true
+maven.ignoreMvnTreeErrors=true
+# rg: added maven.aggregateModules=true for better multi-module support
+maven.aggregateModules=true
+
+gradle.ignoreSourceFiles=true
+# rg: added gradle.aggregateModules=true for better multi-module support
+gradle.aggregateModules=true
+
+npm.includeDevDependencies=false
+# rg: uses npm.runPreStep=false (default), uncomment next line if you don't get good npm results
+#npm.runPreStep=true
+npm.ignoreNpmLsErrors=true
+npm.yarnProject=false
+
+bower.runPreStep=true
+bower.ignoreSourceFiles=true
+
+nuget.runPreStep=true
+
+paket.runPreStep=true
+paket.ignoreSourceFiles=true
+
+python.ignorePipInstallErrors=true
+python.installVirtualenv=true
+python.resolveSetupPyFiles=true
+python.runPipenvPreStep=true
+python.pipenvDevDependencies=true
+python.IgnorePipenvInstallErrors=true
+python.runPoetryPreStep=true
+
+go.collectDependenciesAtRuntime=true
+go.ignoreSourceFiles=true
+
+sbt.runPreStep=true
+
+r.runPreStep=true
+r.cranMirrorUrl=https://cloud.r-project.org/
+
+php.runPreStep=true
+php.includeDevDependencies=true
+
+ruby.installMissingGems=true
+ruby.runBundleInstall=true
+
+cocoapods.runPreStep=true
+
+hex.runPreStep=true
+
+haskell.runPreStep=true
+haskell.ignorePreStepErrors=true
+
+includes=**/*c **/*cc **/*cp **/*cpp **/*cxx **/*c++ **/*h **/*hh **/*hpp **/*hxx **/*h++ **/*m **/*mm **/*pch **/*c# **/*cs **/*csharp **/*go **/*goc **/*js **/*pl **/*plx **/*pm **/*ph **/*cgi **/*fcgi **/*pod **/*psgi **/*al **/*perl **/*t **/*pl6 **/*p6m **/*p6l **/*pm6 **/*nqp **/*6pl **/*6pm **/*p6 **/*php **/*py **/*rb **/*swift **/*java **/*clj **/*cljx **/*cljs **/*cljc **/*jar **/*egg **/*dll **/*tar.gz **/*tgz **/*zip **/*whl **/*gem **/*apk **/*air **/*dmg **/*exe **/*gem **/*gzip **/*msi **/*nupkg **/*swc **/*swf **/tar.bz2 **/pkg.tar.xz **/(u)?deb **/(a)?rpm
+# rg: added **/target to the SCM default excludes
+excludes=*/., **/node_modules, **/src/test, **/testdata, **/*sources.jar, **/*javadoc.jar, **/target
+
+archiveExtractionDepth=0
+archiveIncludes=**/*war **/*ear **/*zip **/*whl **/*tar.gz **/*tgz **/*tar **/*car
+archiveExcludes=**/*sources.jar **/*javadoc.jar


### PR DESCRIPTION
This moves randy's suggested UA config into its own file (whitesource_rg.config), and updates the whitesource.config file with the real defaults. This allows us to maintain a whitesource.config file that reflects the true defaults for repo integrations
The values in whitesource.config are based on the documentation and cross checked against the defaults used by the GHE integration v22.5.2.1